### PR TITLE
include functional

### DIFF
--- a/include/core/dcp/logic/DcpManager.hpp
+++ b/include/core/dcp/logic/DcpManager.hpp
@@ -12,7 +12,7 @@
 
 #include <dcp/model/pdu/DcpPdu.hpp>
 #include <dcp/model/constant/DcpError.hpp>
-
+#include <functional>
 struct DcpManager{
     std::function<void(DcpPdu&)> receive;
     std::function<void(const DcpError)> reportError;


### PR DESCRIPTION
Hello! 
I just build the DCP libary on a fresh ubuntu 18.04  and got the error message, 
'function' in namespace 'std' does not name a template type
thus i added the following  #include <functional> then it build just fine.
Kind regards
Clemens

