### PR TITLE
Check input for max size

### DIFF
--- a/include/core/dcp/logic/AbstractDcpManagerSlave.hpp
+++ b/include/core/dcp/logic/AbstractDcpManagerSlave.hpp
@@ -1024,7 +1024,7 @@ protected:
                     case DcpDataType::binary: {
                         if (var.Input.get()->Binary.get()->start.get() != nullptr) {
                             std::shared_ptr<BinaryStartValue> startValue = var.Input.get()->Binary.get()->start;
-                            DcpBinary startBinary(startValue->length, startValue->value, baseSize - 4);
+                            DcpBinary startBinary(startValue->length, startValue->value, baseSize);
                             values[valueReference]->update(startBinary.getPayload(), 0, DcpDataType::binary);
                         }
                         break;
@@ -1197,7 +1197,7 @@ protected:
                     case DcpDataType::binary: {
                         if (var.Output.get()->Binary.get()->start.get() != nullptr) {
                             std::shared_ptr<BinaryStartValue> startValue = var.Output.get()->Binary.get()->start;
-                            DcpBinary startBinary(startValue->length, startValue->value, baseSize - 4);
+                            DcpBinary startBinary(startValue->length, startValue->value, baseSize);
                             values[valueReference]->update(startBinary.getPayload(), 0, DcpDataType::binary);
                         }
                         break;
@@ -1369,7 +1369,7 @@ protected:
                     case DcpDataType::binary: {
                         if (var.Parameter.get()->Binary.get()->start.get() != nullptr) {
                             std::shared_ptr<BinaryStartValue> startValue = var.Parameter.get()->Binary.get()->start;
-                            DcpBinary startBinary(startValue->length, startValue->value, baseSize - 4);
+                            DcpBinary startBinary(startValue->length, startValue->value, baseSize);
                             values[valueReference]->update(startBinary.getPayload(), 0, DcpDataType::binary);
                         }
                         break;

--- a/include/core/dcp/logic/AbstractDcpManagerSlave.hpp
+++ b/include/core/dcp/logic/AbstractDcpManagerSlave.hpp
@@ -295,8 +295,12 @@ public:
                     std::pair<uint64_t, DcpDataType> p = vrsToReceive[i];
                     uint64_t valueReference = p.first;
                     DcpDataType sourceDataType = p.second;
-
-                    offset += values[valueReference]->update(data.getPayload(), offset, sourceDataType);
+                    try {
+                        offset += values[valueReference]->update(data.getPayload(), offset, sourceDataType);
+                    }
+                    catch (std::range_error) {
+                        Log(INVALID_PAYLOAD, valueReference);
+                    }
 #ifdef DEBUG
                     Log(ASSIGNED_INPUT, valueReference, sourceDataType,
                         slavedescription::getDataType(slaveDescription, valueReference));
@@ -340,7 +344,12 @@ public:
                         updateStructualDependencies(valueReference, value);
                     } else {
                         checkForUpdatedStructure(valueReference);
-                        offset += values[valueReference]->update(param.getConfiguration(), offset, sourceDataType);
+                        try {
+                            offset += values[valueReference]->update(param.getConfiguration(), offset, sourceDataType);
+                        }
+                        catch (std::range_error) {
+                            Log(INVALID_PAYLOAD, valueReference);
+                        }
                     }
                 }
                 break;
@@ -373,8 +382,13 @@ public:
                     updateStructualDependencies(valueReference, value);
                 } else {
                     checkForUpdatedStructure(parameter.getParameterVr());
-                    values[valueReference]->update(parameter.getConfiguration(), 0,
-                                                   slavedescription::getDataType(slaveDescription, valueReference));
+                    try {
+                        values[valueReference]->update(parameter.getConfiguration(), 0,
+                                                       slavedescription::getDataType(slaveDescription, valueReference));
+                    }
+                    catch (std::range_error) {
+                        Log(INVALID_PAYLOAD, valueReference);
+                    }
                 }
                 break;
             }

--- a/include/core/dcp/logic/DCPSlaveErrorCodes.hpp
+++ b/include/core/dcp/logic/DCPSlaveErrorCodes.hpp
@@ -147,6 +147,8 @@ static const LogTemplate INVALID_UUID = LogTemplate(logId++, LogCategory::DCP_LI
                                              {DcpDataType::string, DcpDataType::string});
 static const LogTemplate INVALID_OP_MODE = LogTemplate(logId++, LogCategory::DCP_LIB_SLAVE, DcpLogLevel::LVL_ERROR,
                                                 "Operation Mode %uint8 is not supported.", {DcpDataType::opMode});
+static const LogTemplate INVALID_PAYLOAD = LogTemplate(logId++, LogCategory::DCP_LIB_SLAVE, DcpLogLevel::LVL_ERROR,
+                                                "Invalid Payload for value reference %uint64. MaxSize exceeded. Input truncated.", { DcpDataType::uint64 });
 static const LogTemplate INVALID_MAJOR_VERSION = LogTemplate(logId++, LogCategory::DCP_LIB_SLAVE, DcpLogLevel::LVL_ERROR,
                                                       "The requested major version (%uint8) is not supported by this slave (DCP %uint8.%uint8)",
                                                       {DcpDataType::uint8, DcpDataType::uint8, DcpDataType::uint8});

--- a/include/core/dcp/model/DcpBinary.hpp
+++ b/include/core/dcp/model/DcpBinary.hpp
@@ -22,7 +22,7 @@ public:
     }
 
     DcpBinary(uint32_t length, uint8_t* binary, uint32_t maxSize){
-        payload = new uint8_t[maxSize];
+        payload = new uint8_t[maxSize + 4];
         setBinary(length, binary);
         managed = true;
     }

--- a/include/core/dcp/model/LogEntry.hpp
+++ b/include/core/dcp/model/LogEntry.hpp
@@ -132,6 +132,11 @@ public:
                     offset += 1;
                     break;
                 }
+                case DcpDataType::pduType: {
+                    value = to_string(*((DcpPduType*)(payload + offset)));
+                    offset += 1;
+                    break;
+                }
                 case DcpDataType::dataType: {
                     value = to_string(*((DcpDataType*)(payload + offset)));
                     offset += 1;

--- a/include/core/dcp/model/MultiDimValue.hpp
+++ b/include/core/dcp/model/MultiDimValue.hpp
@@ -145,13 +145,23 @@ public:
             INNER_SWITCH_END
             case DcpDataType::binary:
             case DcpDataType::string:
+                bool invalidPayload = false;
                 for (int i = 0; i < numberOfAssignments; i++) {
                         uint32_t& length = *((uint32_t*)(payload + offset));
                         uint32_t& newLength = *((uint32_t*)(newPayload + (start + otherOffset)));
-                        length = newLength;
-                        std::memcpy(payload + (offset + 4), newPayload + (start + otherOffset + 4), newLength);
+                        if (newLength <= baseSize) {
+                            length = newLength;
+                        }
+                        else {
+                            length = baseSize;
+                            invalidPayload = true;
+                        }
+                        std::memcpy(payload + (offset + 4), newPayload + (start + otherOffset + 4), length);
                         offset += baseSize;
                         otherOffset += (newLength + 4);
+                }
+                if(invalidPayload) {
+                    throw std::range_error("maxSize exceeded");
                 }
                 break;
         }

--- a/include/core/dcp/model/pdu/DcpPduCfgInput.hpp
+++ b/include/core/dcp/model/pdu/DcpPduCfgInput.hpp
@@ -74,7 +74,7 @@ public:
      */
     virtual std::ostream &operator<<(std::ostream &os) {
         DcpPduBasic::operator<<(os);
-        os << " data_id =" << getDataId();
+        os << " data_id=" << getDataId();
         os << " pos=" << getPos();
         os << " target_vr=" << getTargetVr();
         os << " source_data_type=" << getSourceDataType();

--- a/include/core/dcp/model/pdu/DcpPduCfgNetworkInformation.hpp
+++ b/include/core/dcp/model/pdu/DcpPduCfgNetworkInformation.hpp
@@ -47,7 +47,7 @@ public:
      */
     virtual std::ostream &operator<<(std::ostream &os) {
         DcpPduBasic::operator<<(os);
-        os << " data_id =" << getDataId();
+        os << " data_id=" << getDataId();
         os << " transport_protocol=" << getTransportProtocol();
         return os;
     }

--- a/include/core/dcp/model/pdu/DcpPduCfgOutput.hpp
+++ b/include/core/dcp/model/pdu/DcpPduCfgOutput.hpp
@@ -66,7 +66,7 @@ public:
      */
     virtual std::ostream &operator<<(std::ostream &os) {
         DcpPduBasic::operator<<(os);
-        os << " data_id =" << getDataId();
+        os << " data_id=" << getDataId();
         os << " pos=" << getPos();
         os << " source_vr=" << getSourceVr();
         return os;

--- a/include/ethernet/dcp/driver/ethernet/udp/helper/UdpHelper.hpp
+++ b/include/ethernet/dcp/driver/ethernet/udp/helper/UdpHelper.hpp
@@ -109,7 +109,10 @@ public:
     void close() {
         //one in asio queue, one existing in driver
         if(shared_from_this().use_count() == 2){
-            socket->close();
+            if (started && socket != nullptr) {
+                socket->close();
+                started = false;
+            }
 #if defined(DEBUG)
             Log(SOCKET_CLOSED, Udp::protocolName, to_string(endpoint));
 #endif


### PR DESCRIPTION
Fix for #24 
I could not reproduce a crash. 
But yes, if a PDU with binary/string payload is received we need to check its length against the maxSize of the variable to updated before we copy into its memory.
Fix: truncate to maxSize and report error.
TODO: CFG_param in such situation must result in Nack.
Fixes #24 