### PR TITLE
Fix MultiDimValue input handling

### DIFF
--- a/include/core/dcp/logic/AbstractDcpManagerSlave.cpp
+++ b/include/core/dcp/logic/AbstractDcpManagerSlave.cpp
@@ -1425,7 +1425,7 @@ bool AbstractDcpManagerSlave::checkForError(DcpPdu &msg) {
                             correctLength += *((uint16_t *) (aciPduData.getPayload() + correctLength)) + 4;
                             break;
                         default:
-                            correctLength += getDcpDataTypeSize(pos.second.second);
+                            correctLength += values[pos.second.first]->getPayloadSize();
                     }
                 }
                 if (aciPduData.getPduSize() != (correctLength + 5)) {

--- a/include/core/dcp/model/MultiDimValue.hpp
+++ b/include/core/dcp/model/MultiDimValue.hpp
@@ -66,6 +66,10 @@ public:
         return baseSize;
     }
 
+    inline size_t getPayloadSize(){
+        return baseSize * numberOfAssignments;
+    }
+
     template<typename T>
     inline T getValue() {
         static_assert(std::is_pointer<T>::value, "Expected a pointer");


### PR DESCRIPTION
Fixes handling of constant dimension variables.
Variables with dynamic dimensions (linked_vr) wasn't tested yet.