### PR TITLE
Bugfix/RTstate

### DIFF
--- a/include/slave/dcp/logic/DcpManagerSlave.hpp
+++ b/include/slave/dcp/logic/DcpManagerSlave.hpp
@@ -819,16 +819,19 @@ protected:
                 break;
             }
             case DcpState::SYNCHRONIZED: {
-                mtxInput.wait();
-                mtxOutput.wait();
+                if (state == DcpState::RUNNING || state == DcpState::SYNCHRONIZED) {
+                    mtxInput.wait();
+                    mtxOutput.wait();
 
-                if (asynchronousCallback[DcpCallbackTypes::SYNCHRONIZED_STEP]) {
-                    std::thread t(synchronizedStepCallback, steps);
-                    t.detach();
-                } else {
-                    synchronizedStepCallback(steps);
-                    std::thread t(&DcpManagerSlave::realtimeStepFinished, this);
-                    t.detach();
+                    if (asynchronousCallback[DcpCallbackTypes::SYNCHRONIZED_STEP]) {
+                        std::thread t(synchronizedStepCallback, steps);
+                        t.detach();
+                    }
+                    else {
+                        synchronizedStepCallback(steps);
+                        std::thread t(&DcpManagerSlave::realtimeStepFinished, this);
+                        t.detach();
+                    }
                 }
                 break;
             }

--- a/include/slave/dcp/logic/DcpManagerSlave.hpp
+++ b/include/slave/dcp/logic/DcpManagerSlave.hpp
@@ -856,6 +856,7 @@ protected:
                                                                    * ((double) steps)) * 1000000.0));
         //steps = newSteps;
         std::this_thread::sleep_until(nextCommunication);
+        realtimeState = state;
         startRealtimeStep();
     }
 


### PR DESCRIPTION
Updates the realtimeState with the actual state of the slave after the step is finished.
Fixes #15 
This prevents situations such as in #15 where calculations are started regardless of the state of the DCPslave.
Only execute SynchronizeCallback in appropriate states.
