### PR TITLE
Make header-defined function inlined

### DIFF
--- a/include/core/dcp/model/pdu/IpToStr.hpp
+++ b/include/core/dcp/model/pdu/IpToStr.hpp
@@ -3,7 +3,7 @@
 
 #if defined(DEBUG) || defined(LOGGING)
 #include <string>
-std::string ipToString(const uint32_t ip) {
+inline std::string ipToString(const uint32_t ip) {
     return std::to_string(ip >> 24 & 0xFF) + "." + std::to_string(ip >> 16 & 0xFF) + "." + std::to_string(ip >> 8 & 0xFF) + "." + std::to_string(ip & 0xFF);
 }
 #endif // defined(DEBUG) || defined(LOGGING)


### PR DESCRIPTION
The `ipToString()` function is defined in its header file, which causes multiple declaration errors if the header is included by multiple source files. Making it `inline` solves this.

The alternative solution would be to move the definition to a source file.