### PR TITLE
Add missing include to DcpPduType.hpp

### DIFF
--- a/include/core/dcp/model/LogEntry.hpp
+++ b/include/core/dcp/model/LogEntry.hpp
@@ -19,6 +19,7 @@
 #include <dcp/model/DcpTypes.hpp>
 #include <dcp/model/constant/DcpState.hpp>
 #include <dcp/model/constant/DcpOpMode.hpp>
+#include <dcp/model/constant/DcpPduType.hpp>
 
 class LogEntry {
 public:


### PR DESCRIPTION
`DcpPduType` seems to be undefined with some compilers, causing an error on this line:

`value = to_string(*((DcpPduType*)(payload + offset)));`

Including the file directly should solve this problem (as is already done with other types)