### PR TITLE
DCPLib automated container image creation.

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+OS="redhat" # Pass any of ubuntu, redhat, rockylinux
+VER="ubi8"  # ubuntu: 18.04, 22.04; redhat: ubi8, ubi9; rockylinux: 8, 9
+
+DOCKER=docker # You might use podman as well
+DOCKERFILE=Dockerfile.tmp
+
+
+cat docker/1_${OS}_$VER.Dockerfile > $DOCKERFILE
+cat docker/2_build.Dockerfile >> $DOCKERFILE
+cat docker/3_run_test.Dockerfile >> $DOCKERFILE
+
+# During development you might remove the --no-cache option for faster rebuilds.
+$DOCKER build -t dcp/${OS}_$VER -f $DOCKERFILE \
+  --build-arg LINUX_DISTRIBUTION_IMAGE=$OS \
+  --build-arg LINUX_DISTRIBUTION_TAG=$VER . \
+  --no-cache
+
+# If you want to run the last built image comment out the following two lines
+#$DOCKER run --name testcontainer -it localhost/dcp/${OS}_$VER:latest
+#$DOCKER container rm testcontainer

--- a/build_examples.sh
+++ b/build_examples.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# This shell script is supposed to be run in a docker-container with already installed DCPLib and asio libs.
+set -e
+
+if [[ $(basename ${PWD}) != "DCPLib" ]]; then
+  echo "Please run this script in DCPLib folder to make sure the right folders are accessed."
+  exit -1
+fi
+
+pushd example
+  for example in $(ls -d */); do
+    pushd $example
+      echo "In folder $example"
+      mkdir -p build
+      pushd build
+        cmake ..
+        cmake --build .
+      popd
+    popd
+  done
+popd

--- a/docker/1_redhat_ubi8.Dockerfile
+++ b/docker/1_redhat_ubi8.Dockerfile
@@ -1,0 +1,47 @@
+ARG GH_USER="modelica"
+ARG GH_PROJECT="DCPLib"
+ARG LINUX_DISTRIBUTION_IMAGE="redhat"
+ARG LINUX_DISTRIBUTION_TAG="ubi8"
+
+FROM docker.io/${LINUX_DISTRIBUTION_IMAGE}/${LINUX_DISTRIBUTION_TAG}
+
+# LABEL about the custom image
+LABEL maintainer="alexander.nikolic@v2c2.at"
+LABEL version="0.1"
+LABEL description="This is a custom Docker Image for \
+the DCP installation."
+
+# Globally defined ARGs need to be consumed in this scoped by using ARG after the FROM
+ARG GH_USER
+ARG GH_PROJECT
+ARG LINUX_DISTRIBUTION_IMAGE
+ARG LINUX_DISTRIBUTION_TAG
+
+RUN echo $GH_USER $GH_PROJECT $LINUX_DISTRIBUTION_IMAGE $LINUX_DISTRIBUTION_TAG
+RUN cat /etc/redhat-release
+
+# It might be necessary to enable EPEL, see https://www.redhat.com/en/blog/install-epel-linux
+# dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+# DOES HAVE xerces-c-devel
+# DOES NOT HAVE asio-devel
+RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+RUN dnf -y update && \
+    dnf -y install --nodocs \
+    zip \
+    git \
+    cmake \
+    gcc \
+    gcc-c++ \
+    libstdc++-static \
+    make \
+    kernel-headers \
+    libzip-devel \
+    openssl-devel \
+    xerces-c-devel && dnf clean all -y && rm -rf /var/cache/dnf
+
+WORKDIR /src
+
+RUN curl -L -o "asio.zip" -O https://sourceforge.net/projects/asio/files/asio/1.12.2%20%28Stable%29/asio-1.12.2.zip/download
+RUN unzip asio.zip
+RUN cd asio-1.12.2/ && ./configure --without-boost && make && make install && cd ..

--- a/docker/1_redhat_ubi9.Dockerfile
+++ b/docker/1_redhat_ubi9.Dockerfile
@@ -1,0 +1,45 @@
+ARG GH_USER="modelica"
+ARG GH_PROJECT="DCPLib"
+ARG LINUX_DISTRIBUTION_IMAGE="redhat"
+ARG LINUX_DISTRIBUTION_TAG="ubi9"
+
+FROM docker.io/${LINUX_DISTRIBUTION_IMAGE}/${LINUX_DISTRIBUTION_TAG}
+
+# LABEL about the custom image
+LABEL maintainer="alexander.nikolic@v2c2.at"
+LABEL version="0.1"
+LABEL description="This is a custom Docker Image for \
+the DCP installation."
+
+# Globally defined ARGs need to be consumed in this scoped by using ARG after the FROM
+ARG GH_USER
+ARG GH_PROJECT
+ARG LINUX_DISTRIBUTION_IMAGE
+ARG LINUX_DISTRIBUTION_TAG
+
+RUN echo $GH_USER $GH_PROJECT $LINUX_DISTRIBUTION_IMAGE $LINUX_DISTRIBUTION_TAG
+RUN cat /etc/redhat-release
+
+
+# It might be necessary to enable EPEL, see https://www.redhat.com/en/blog/install-epel-linux
+# subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
+# dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
+# DOES HAVE xerces-c-devel
+# DOES NOT HAVE asio-devel
+RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
+RUN dnf -y update && \
+    dnf -y install --nodocs \
+    zip \
+    git \
+    cmake \
+    gcc \
+    gcc-c++ \
+    libstdc++-static \
+    make \
+    kernel-headers \
+    libzip-devel \
+    xerces-c-devel \
+    asio-devel && dnf clean all -y && rm -rf /var/cache/dnf
+

--- a/docker/1_rockylinux_8.Dockerfile
+++ b/docker/1_rockylinux_8.Dockerfile
@@ -1,0 +1,50 @@
+ARG GH_USER="modelica"
+ARG GH_PROJECT="DCPLib"
+ARG LINUX_DISTRIBUTION_IMAGE="rockylinux"
+ARG LINUX_DISTRIBUTION_TAG="8"
+
+FROM docker.io/${LINUX_DISTRIBUTION_IMAGE}:${LINUX_DISTRIBUTION_TAG}
+# Globally defined ARGs need to be consumed in this scoped by using ARG after the FROM
+ARG GH_USER
+ARG GH_PROJECT
+ARG LINUX_DISTRIBUTION_IMAGE
+ARG LINUX_DISTRIBUTION_TAG
+
+RUN echo $GH_USER $GH_PROJECT $LINUX_DISTRIBUTION_IMAGE $LINUX_DISTRIBUTION_TAG
+
+# LABEL about the custom image
+LABEL maintainer="alexander.nikolic@v2c2.at"
+LABEL version="0.1"
+LABEL description="This is a custom Docker Image for \
+the DCP installation."
+
+RUN echo $GH_USER $GH_PROJECT $LINUX_DISTRIBUTION_IMAGE $LINUX_DISTRIBUTION_TAG
+RUN cat /etc/redhat-release
+
+# It might be necessary to enable EPEL: dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+# DOES HAVE xerces-c-devel
+# DOES NOT HAVE asio-devel
+#RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN dnf -y install epel-release && \
+    dnf -y config-manager --set-enabled powertools && \
+    dnf -y install --nobest --nodocs \
+    zip \
+    git \
+    ccache \
+    cmake \
+    gcc \
+    gcc-c++ \
+    libstdc++-static \
+    make \
+    kernel-headers \
+    libzip-devel \
+    openssl-devel \
+    scl-utils \
+    xerces-c-devel && dnf clean all -y && rm -rf /var/cache/dnf
+
+
+WORKDIR /src
+
+RUN curl -L -o "asio.zip" -O https://sourceforge.net/projects/asio/files/asio/1.12.2%20%28Stable%29/asio-1.12.2.zip/download
+RUN unzip asio.zip
+RUN cd asio-1.12.2/ && scl_source load gcc-toolset-12 && ./configure --without-boost && make && make install && cd ..

--- a/docker/1_rockylinux_9.Dockerfile
+++ b/docker/1_rockylinux_9.Dockerfile
@@ -1,0 +1,44 @@
+ARG GH_USER="modelica"
+ARG GH_PROJECT="DCPLib"
+ARG LINUX_DISTRIBUTION_IMAGE="rockylinux"
+ARG LINUX_DISTRIBUTION_TAG="9"
+
+FROM docker.io/${LINUX_DISTRIBUTION_IMAGE}:${LINUX_DISTRIBUTION_TAG}
+
+# LABEL about the custom image
+LABEL maintainer="alexander.nikolic@v2c2.at"
+LABEL version="0.1"
+LABEL description="This is a custom Docker Image for \
+the DCP installation."
+
+# Globally defined ARGs need to be consumed in this scoped by using ARG after the FROM
+ARG GH_USER
+ARG GH_PROJECT
+ARG LINUX_DISTRIBUTION_IMAGE
+ARG LINUX_DISTRIBUTION_TAG
+
+RUN echo $GH_USER $GH_PROJECT $LINUX_DISTRIBUTION_IMAGE $LINUX_DISTRIBUTION_TAG
+RUN cat /etc/redhat-release
+
+
+# It might be necessary to enable EPEL, see https://www.redhat.com/en/blog/install-epel-linux
+# subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
+# dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+# DOES HAVE xerces-c-devel
+
+RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
+RUN dnf -y config-manager --set-enabled crb && \
+    dnf -y install --nodocs \
+    zip \
+    git \
+    cmake \
+    gcc \
+    gcc-c++ \
+    libstdc++-static \
+    make \
+    kernel-headers \
+    libzip-devel \
+    xerces-c-devel \
+    asio-devel && dnf clean all -y && rm -rf /var/cache/dnf
+

--- a/docker/1_ubuntu_18.04.Dockerfile
+++ b/docker/1_ubuntu_18.04.Dockerfile
@@ -1,0 +1,35 @@
+ARG GH_USER="modelica"
+ARG GH_PROJECT="DCPLib"
+ARG LINUX_DISTRIBUTION_IMAGE="ubuntu"
+ARG LINUX_DISTRIBUTION_TAG="18.04"
+
+FROM ${LINUX_DISTRIBUTION_IMAGE}:${LINUX_DISTRIBUTION_TAG}
+
+# LABEL about the custom image
+LABEL maintainer="alexander.nikolic@v2c2.at"
+LABEL version="0.1"
+LABEL description="This is a custom Docker Image for \
+the DCP installation."
+
+# Globally defined ARGs need to be consumed in this scoped by using ARG after the FROM
+ARG GH_USER
+ARG GH_PROJECT
+ARG LINUX_DISTRIBUTION_IMAGE
+ARG LINUX_DISTRIBUTION_TAG
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN echo $GH_USER $GH_PROJECT $LINUX_DISTRIBUTION_IMAGE $LINUX_DISTRIBUTION_TAG
+RUN cat /etc/os-release
+
+RUN apt-get update && apt-get install -y \
+    git \
+    cmake \
+    build-essential \
+    uuid-dev \
+    libkrb5-dev \
+    libcurl4-openssl-dev \
+    libasio-dev \
+    libxerces-c-dev \
+    libzip-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt clean

--- a/docker/1_ubuntu_22.04.Dockerfile
+++ b/docker/1_ubuntu_22.04.Dockerfile
@@ -1,0 +1,35 @@
+ARG GH_USER="modelica"
+ARG GH_PROJECT="DCPLib"
+ARG LINUX_DISTRIBUTION_IMAGE="ubuntu"
+ARG LINUX_DISTRIBUTION_TAG="22.04"
+
+FROM ${LINUX_DISTRIBUTION_IMAGE}:${LINUX_DISTRIBUTION_TAG}
+
+# LABEL about the custom image
+LABEL maintainer="alexander.nikolic@v2c2.at"
+LABEL version="0.1"
+LABEL description="This is a custom Docker Image for \
+the DCP installation."
+
+# Globally defined ARGs need to be consumed in this scoped by using ARG after the FROM
+ARG GH_USER
+ARG GH_PROJECT
+ARG LINUX_DISTRIBUTION_IMAGE
+ARG LINUX_DISTRIBUTION_TAG
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN echo $GH_USER $GH_PROJECT $LINUX_DISTRIBUTION_IMAGE $LINUX_DISTRIBUTION_TAG
+RUN cat /etc/os-release
+
+RUN apt-get update && apt-get install -y \
+    git \
+    cmake \
+    build-essential \
+    uuid-dev \
+    libkrb5-dev \
+    libcurl4-openssl-dev \
+    libasio-dev \
+    libxerces-c-dev \
+    libzip-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt clean

--- a/docker/2_build.Dockerfile
+++ b/docker/2_build.Dockerfile
@@ -1,0 +1,28 @@
+################################################
+# DCPLib build
+#
+# Pulls the repository and builds the library.
+# Afterwards it builds available examples.
+# Later, built examples will be run for testing
+################################################
+
+WORKDIR /src
+
+# Clone the GitLab repository into the project directory
+RUN git clone --recursive https://github.com/$GH_USER/$GH_PROJECT.git \
+    && mv $GH_PROJECT /$GH_PROJECT
+
+# Build using CMake and make; Installing the built library
+RUN mkdir -p /$GH_PROJECT/build \
+    && cd /$GH_PROJECT/build \
+    && cmake .. \
+    && cmake --build . --target install
+
+
+# Build examples
+COPY build_examples.sh /DCPLib/build_examples.sh
+RUN chmod +x /DCPLib/build_examples.sh
+
+WORKDIR /DCPLib
+RUN ./build_examples.sh
+

--- a/docker/3_run_test.Dockerfile
+++ b/docker/3_run_test.Dockerfile
@@ -1,0 +1,17 @@
+################################################
+# DCPLib test
+#
+# DCPLib:
+# Runs one of the previously built tests to
+# assert correct compilation, linking and
+# correct dependency resolution.
+#
+################################################
+
+COPY run_example.sh /DCPLib/run_example.sh
+
+
+# Run Tests for DCPLib
+WORKDIR /DCPLib
+RUN chmod +x /DCPLib/run_example.sh
+RUN ./run_example.sh

--- a/run_example.sh
+++ b/run_example.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+cd /DCPLib/example/slave
+./build/dcpslave &
+SLAVEID=$!
+echo "Slave Started."
+
+sleep 5 &
+SLEEPID=$!
+echo "Sleeping for readiness..."
+
+wait $SLEEPID
+echo "Sleep over."
+cd /DCPLib/example/master
+./build/dcpmaster &
+MASTERID=$!
+
+
+wait $MASTERID
+echo "Master Done."
+
+kill $SLAVEID
+
+echo "Slave Ended."
+


### PR DESCRIPTION
build_docker.sh:
  Create docker image containing a freshly built DCPLib with necessary dependencies preinstalled.
  Change $OS to choose base image and $VER to choose version.
  Currently supported base images: redhat_ubi{8,9}, rockylinux{8,9}, ubuntu{18.04,22.04}
  A temporary Dockerfile is created to reflect the configuration of choice and then the image is built during which a test of the DCPLib build is run.

build_examples.sh: Builds all examples (currently in source tree) automatically.
run_example.sh: Is used in the docker images to test the build by running one example.