### PR TITLE
Automated windows build: build.bat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,12 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/core DESTINATION include/DCPLib)
 
 if(BUILD_ALL OR BUILD_ETHERNET)
     find_package(Threads REQUIRED)
-	find_package(ASIO REQUIRED )
+    if(WIN32)
+	    find_package(asio REQUIRED )
+    else(WIN32)
+	    find_package(ASIO REQUIRED )
+    endif(WIN32)
+
 
     ##dcplib ethernet
     add_library(Ethernet INTERFACE)
@@ -165,21 +170,30 @@ if(BUILD_ALL OR BUILD_XML)
 endif(BUILD_ALL OR BUILD_XML)
 
 if(BUILD_ALL OR BUILD_ZIP)
-	find_package(Zip REQUIRED)
+    set(ziplib_name "")
+    set(ziplib_target "")
+    if(WIN32)
+        set(ziplib_name "libzip")
+        set(ziplib_target "libzip::zip")
+    else(WIN32)
+        set(ziplib_name "Zip")
+        set(ziplib_target "ZIP::ZIP")
+    endif(WIN32)
 
-    add_library(Zip INTERFACE)
-    add_library(DCPLib::Zip ALIAS Zip)
+    find_package(${ziplib_name} REQUIRED)
+    add_library(${ziplib_name} INTERFACE)
+    add_library(DCPLib::Zip ALIAS ${ziplib_name})
 
-    target_link_libraries(Zip INTERFACE DCPLib::Xml ZIP::ZIP)
+    target_link_libraries(${ziplib_name} INTERFACE DCPLib::Xml ${ziplib_target})
 
-    target_include_directories(Zip INTERFACE
+    target_include_directories(${ziplib_name} INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/zip>
             $<INSTALL_INTERFACE:include/DCPLib/zip>
             )
 
-    install(TARGETS Zip
+    install(TARGETS ${ziplib_name}
             EXPORT DCPLib-targets
-            COMPONENT Zip
+            COMPONENT ${ziplib_name}
             ARCHIVE DESTINATION lib
             LIBRARY DESTINATION lib
             RUNTIME DESTINATION bin)

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,76 @@
+@echo off
+set back=%cd%
+set BUILD_CONFIG=Release
+
+if not exist dependencies (mkdir dependencies)
+cd dependencies
+
+WHERE vcpkg --version >nul 2>nul
+REM IF %ERRORLEVEL% NEQ 0 (ECHO vcpkg was not found && cd %back% && EXIT /b 1)
+IF %ERRORLEVEL% NEQ 0 (
+  if not exist %cd%\vcpkg\scripts\buildsystems\vcpkg.cmake (
+    ECHO vcpkg was not found, installing
+    if not exist vcpkg (git clone https://github.com/microsoft/vcpkg.git)
+    cd vcpkg
+    if not exist vcpkg.exe ( bootstrap-vcpkg.bat -disableMetrics )
+    set VCPKG=%cd%\vcpkg\vcpkg.exe
+    %VCPKG% integrate install || ECHO Installed vcpkg locally
+  )
+) ELSE (
+  ECHO vcpkg found
+  set VCPKG=vcpkg
+)
+
+%VCPKG% --version
+
+cd %back%
+
+cd dependencies
+WHERE cmake --version >nul 2>nul
+REM IF %ERRORLEVEL% NEQ 0 (ECHO cmake was not found && cd %back% && EXIT /b 1)
+IF %ERRORLEVEL% NEQ 0 (
+  ECHO cmake was not found, installing
+  if not exist cmake.zip ( curl -L -o cmake.zip https://github.com/Kitware/CMake/releases/download/v4.0.0-rc5/cmake-4.0.0-rc5-windows-x86_64.zip )
+  REM if not exist cmake (tar -xf cmake.zip)
+  if not exist cmake (mkdir cmake && tar -xf cmake.zip --strip-components=1 -C cmake)
+  cd cmake
+  cd bin
+  set CMAKE=%cd%\cmake\bin\cmake.exe
+) ELSE (
+  ECHO cmake found
+  set CMAKE=cmake
+)
+
+%CMAKE% --version
+
+cd %back%
+
+%VCPKG% install asio xerces-c libzip
+
+if not exist build (mkdir build)
+
+cd build
+if not exist install (mkdir install)
+set VCPKG_TC_FILE=C:/Users/%USERNAME%/Downloads/dcp_PR/DCPLib/dependencies/vcpkg/scripts/buildsystems/vcpkg.cmake
+%CMAKE% .. -G "Visual Studio 17 2022" -A x64 -DCMAKE_TOOLCHAIN_FILE=%VCPKG_TC_FILE% -DCMAKE_INSTALL_PREFIX=install
+
+%CMAKE% --build . --target=install --config %BUILD_CONFIG%
+
+cd %back%
+
+
+REM Build Examples
+
+for /f "tokens=*" %%G in ('dir /b /a:d "example\*"') do (
+  echo Found %back%\example\%%G
+  if not exist %back%\build\example\%%G (mkdir %back%\build\example\%%G)
+  cd %back%\build\example\%%G
+  %CMAKE% %back%\example\%%G -G "Visual Studio 17 2022" -A x64 -DCMAKE_TOOLCHAIN_FILE=%VCPKG_TC_FILE% -DDCPLib_DIR=%back%\build\install\lib\DCPLib -DCMAKE_INSTALL_PREFIX=install
+  %CMAKE% --build . --config %BUILD_CONFIG%
+  REM copy /Y %back%\example\%%G\*.xml %back%\build\example\%%G
+  cd %back%
+)
+
+REM make sure the XML File is available for any build configuration!!! (e.g. master needs one)
+
+run_test.bat %cd% %BUILD_CONFIG%

--- a/example/master/CMakeLists.txt
+++ b/example/master/CMakeLists.txt
@@ -26,4 +26,11 @@ file(GLOB_RECURSE dcpmaster_src_files src/*.cpp src/*.h )
 add_executable(dcpmaster ${dcpmaster_src_files})
 target_link_libraries(dcpmaster DCPLib::Ethernet DCPLib::Master DCPLib::Xml)
 
+add_custom_command(TARGET dcpmaster POST_BUILD
+  COMMAND "${CMAKE_COMMAND}" -E copy
+    ${CMAKE_SOURCE_DIR}/Example-Slave-Description.xml
+    $<TARGET_FILE_DIR:dcpmaster>
+  COMMENT "Copied description XML file."
+)
+
 install(TARGETS dcpmaster DESTINATION bin)

--- a/example/spring_damper_master/CMakeLists.txt
+++ b/example/spring_damper_master/CMakeLists.txt
@@ -26,4 +26,14 @@ file(GLOB_RECURSE dcp_msd_master_src_files src/*.cpp src/*.h )
 add_executable(dcp_msd_master ${dcp_msd_master_src_files})
 target_link_libraries(dcp_msd_master DCPLib::Ethernet DCPLib::Master DCPLib::Xml)
 
+add_custom_command(TARGET dcp_msd_master POST_BUILD
+  COMMAND "${CMAKE_COMMAND}" -E copy
+    ${CMAKE_SOURCE_DIR}/MSD1-Slave-Description.xml
+    $<TARGET_FILE_DIR:dcp_msd_master>
+  COMMAND "${CMAKE_COMMAND}" -E copy
+    ${CMAKE_SOURCE_DIR}/MSD2-Slave-Description.xml
+    $<TARGET_FILE_DIR:dcp_msd_master>
+  COMMENT "Copied description XML file."
+)
+
 install(TARGETS dcp_msd_master DESTINATION bin)

--- a/example/struc_param_master/CMakeLists.txt
+++ b/example/struc_param_master/CMakeLists.txt
@@ -26,4 +26,11 @@ file(GLOB_RECURSE struc_param_master_src_files src/*.cpp src/*.h )
 add_executable(struc_param_master ${struc_param_master_src_files})
 target_link_libraries(struc_param_master DCPLib::Ethernet DCPLib::Master DCPLib::Xml)
 
+add_custom_command(TARGET struc_param_master POST_BUILD
+  COMMAND "${CMAKE_COMMAND}" -E copy
+    ${CMAKE_SOURCE_DIR}/StrucParam-Slave-Description.xml
+    $<TARGET_FILE_DIR:struc_param_master>
+  COMMENT "Copied description XML file."
+)
+
 install(TARGETS struc_param_master DESTINATION bin)

--- a/run_test.bat
+++ b/run_test.bat
@@ -1,0 +1,13 @@
+set back=%1
+set BUILD_CONFIG=%2
+
+echo > waiting.tmp
+start cmd /c wrapper.bat %back%\build\example\slave\%BUILD_CONFIG% %back%\build\example\slave\%BUILD_CONFIG%\dcpslave.exe
+cd %back%\build\example\master\%BUILD_CONFIG%
+start /wait %back%\build\example\master\%BUILD_CONFIG%\dcpmaster.exe
+
+:loop
+if exist waiting.tmp goto :loop
+
+taskkill /IM dcpslave.exe /F
+cd %back%

--- a/wrapper.bat
+++ b/wrapper.bat
@@ -1,0 +1,3 @@
+cd %1
+start /wait %2
+del waiting.tmp


### PR DESCRIPTION
Some libraries have different names/case in vcpkg (for windows). Added copying of XML file to TARGET_FILE_DIR for master examples.

in folder dependencies:
  * vcpkg will be installed locally - user has to click no button to not install systemwide.
  * cmake will be downloaded and unzipped

DCPLib and all examples will be built.
Simple test will be run at end of build.