### PR TITLE
fix: initialize generateLogString to allow    arbitrary setter order

### DIFF
--- a/include/core/dcp/logic/AbstractDcpManager.hpp
+++ b/include/core/dcp/logic/AbstractDcpManager.hpp
@@ -101,7 +101,7 @@ protected:
     std::map<uint16_t, uint16_t> parameterSegNumsIn;
 
     std::vector<std::function<void(const LogEntry &)>> logListeners;
-    bool generateLogString;
+    bool generateLogString = false;
 
     uint8_t dcpId;
     uint8_t masterId;


### PR DESCRIPTION
AbstractDcpManager declared bool generateLogString without a default initializer, leaving it uninitialized when the object is heap-allocated.
  
setTimeResListener() has a hidden side effect: if the slave description contains a fixed or recommended time resolution, it immediately calls setTimeRes() internally, which triggers a Log() call. This causes consume() to branch on generateLogString before the user has had a chance to call setGenerateLogString(), resulting in undefined behavior.

Fix:

bool generateLogString = false;

Closes #73.