### PR TITLE
fix: delete logRspBuffer in AbstractDcpManagerSlave destructor

### DIFF
--- a/include/core/dcp/logic/AbstractDcpManagerSlave.hpp
+++ b/include/core/dcp/logic/AbstractDcpManagerSlave.hpp
@@ -75,6 +75,7 @@ public:
 
 
     ~AbstractDcpManagerSlave() {
+        delete[] logRspBuffer;
         for (auto const &entry : values) {
             delete entry.second;
         }


### PR DESCRIPTION
logRspBuffer is allocated in the constructor but never freed in the destructor, causing a 900-byte heap leak on every slave teardown.

Added delete[] logRspBuffer to ~AbstractDcpManagerSlave().

Closes #75.